### PR TITLE
Deploy listener version tag

### DIFF
--- a/snippets/engine-plugin-deployer-version-tag/README.md
+++ b/snippets/engine-plugin-deployer-version-tag/README.md
@@ -1,0 +1,13 @@
+# Version Tag Change Deployer
+
+For each deployment to the engine, the deployment resources are filtered for BPMN files. In each BPMN file, the version tag is set to a default value.
+
+This is proven by the test case.
+
+## Use this plugin
+
+### Camunda Run
+
+Run `mvn clean package` to receive the `jar`-artifact in the `target` folder of the project. 
+
+Then, install the process engine plugin [as described in the docs](https://docs.camunda.org/manual/latest/user-guide/camunda-bpm-run/#process-engine-plugin-registration).

--- a/snippets/engine-plugin-deployer-version-tag/pom.xml
+++ b/snippets/engine-plugin-deployer-version-tag/pom.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.camunda.consulting.example</groupId>
+  <artifactId>version-tag-deployer</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+
+  <name>Camunda Consulting Example Version Tag Deployer</name>
+  <description>An example on a process engine plugin that sets version tags of BPMN files in deployments</description>
+
+  <properties>
+    <camunda.version>7.19.0</camunda.version>
+    <springBoot.version>2.7.6</springBoot.version>
+
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
+    <version.java>17</version.java>
+
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <failOnMissingWebXml>false</failOnMissingWebXml>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.camunda.bpm</groupId>
+        <artifactId>camunda-bom</artifactId>
+        <version>${camunda.version}</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>${springBoot.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.camunda.bpm.assert</groupId>
+        <artifactId>camunda-bpm-assert</artifactId>
+        <version>15.0.0</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
+        <version>3.12.0</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.camunda.bpm</groupId>
+      <artifactId>camunda-engine</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.camunda.bpm</groupId>
+      <artifactId>camunda-bpm-junit5</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.camunda.bpm.assert</groupId>
+      <artifactId>camunda-bpm-assert</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <redirectTestOutputToFile>true</redirectTestOutputToFile>
+          <reportsDirectory>${project.build.directory}/test-reports</reportsDirectory>
+        </configuration>
+      </plugin>
+    </plugins>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>3.0.0-M5</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+</project>

--- a/snippets/engine-plugin-deployer-version-tag/src/main/java/com/camunda/consulting/RegisterDeploymentVersionTagChangePlugin.java
+++ b/snippets/engine-plugin-deployer-version-tag/src/main/java/com/camunda/consulting/RegisterDeploymentVersionTagChangePlugin.java
@@ -1,0 +1,17 @@
+package com.camunda.consulting;
+
+import org.camunda.bpm.engine.impl.cfg.AbstractProcessEnginePlugin;
+import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.camunda.bpm.engine.impl.persistence.deploy.Deployer;
+
+import java.util.ArrayList;
+
+public class RegisterDeploymentVersionTagChangePlugin extends AbstractProcessEnginePlugin {
+  @Override
+  public void preInit(ProcessEngineConfigurationImpl processEngineConfiguration) {
+    if (processEngineConfiguration.getCustomPreDeployers() == null) {
+      processEngineConfiguration.setCustomPreDeployers(new ArrayList<Deployer>());
+    }
+    processEngineConfiguration.getCustomPreDeployers().add(new VersionTagChangeDeployer());
+  }
+}

--- a/snippets/engine-plugin-deployer-version-tag/src/main/java/com/camunda/consulting/VersionTagChangeDeployer.java
+++ b/snippets/engine-plugin-deployer-version-tag/src/main/java/com/camunda/consulting/VersionTagChangeDeployer.java
@@ -5,23 +5,29 @@ import org.camunda.bpm.engine.impl.persistence.entity.DeploymentEntity;
 import org.camunda.bpm.model.bpmn.instance.Process;
 import org.camunda.bpm.model.bpmn.Bpmn;
 import org.camunda.bpm.model.bpmn.BpmnModelInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayInputStream;
 import java.util.Map;
 
 public class VersionTagChangeDeployer implements Deployer {
 
+  private static Logger log = LoggerFactory.getLogger(VersionTagChangeDeployer.class);
+
   @Override
   public void deploy(DeploymentEntity deployment) {
-      deployment
-          .getResources()
-          .entrySet()
-          .stream().filter(e -> e.getKey().endsWith(".bpmn"))
-          .map(Map.Entry::getValue)
-          .forEach(resource -> {
-              BpmnModelInstance modelInstance = Bpmn.readModelFromStream(new ByteArrayInputStream(resource.getBytes()));
-              modelInstance.getModelElementsByType(Process.class).forEach(process -> process.setCamundaVersionTag("my-custom-tag"));
-              resource.setBytes(Bpmn.convertToString(modelInstance).getBytes());
-          });
+    deployment
+      .getResources()
+      .entrySet()
+      .stream()
+      .filter(e -> e.getKey().endsWith(".bpmn"))
+      .peek(e -> log.info("About to change version tag for file {}", e.getKey()))
+      .map(Map.Entry::getValue)
+      .forEach(resource -> {
+        BpmnModelInstance modelInstance = Bpmn.readModelFromStream(new ByteArrayInputStream(resource.getBytes()));
+        modelInstance.getModelElementsByType(Process.class).forEach(process -> process.setCamundaVersionTag("my-custom-tag"));
+        resource.setBytes(Bpmn.convertToString(modelInstance).getBytes());
+    });
   }
 }

--- a/snippets/engine-plugin-deployer-version-tag/src/main/java/com/camunda/consulting/VersionTagChangeDeployer.java
+++ b/snippets/engine-plugin-deployer-version-tag/src/main/java/com/camunda/consulting/VersionTagChangeDeployer.java
@@ -1,0 +1,27 @@
+package com.camunda.consulting;
+
+import org.camunda.bpm.engine.impl.persistence.deploy.Deployer;
+import org.camunda.bpm.engine.impl.persistence.entity.DeploymentEntity;
+import org.camunda.bpm.model.bpmn.instance.Process;
+import org.camunda.bpm.model.bpmn.Bpmn;
+import org.camunda.bpm.model.bpmn.BpmnModelInstance;
+
+import java.io.ByteArrayInputStream;
+import java.util.Map;
+
+public class VersionTagChangeDeployer implements Deployer {
+
+  @Override
+  public void deploy(DeploymentEntity deployment) {
+      deployment
+          .getResources()
+          .entrySet()
+          .stream().filter(e -> e.getKey().endsWith(".bpmn"))
+          .map(Map.Entry::getValue)
+          .forEach(resource -> {
+              BpmnModelInstance modelInstance = Bpmn.readModelFromStream(new ByteArrayInputStream(resource.getBytes()));
+              modelInstance.getModelElementsByType(Process.class).forEach(process -> process.setCamundaVersionTag("my-custom-tag"));
+              resource.setBytes(Bpmn.convertToString(modelInstance).getBytes());
+          });
+  }
+}

--- a/snippets/engine-plugin-deployer-version-tag/src/test/java/com/camunda/consulting/ProcessEngineTest.java
+++ b/snippets/engine-plugin-deployer-version-tag/src/test/java/com/camunda/consulting/ProcessEngineTest.java
@@ -24,11 +24,11 @@ public class ProcessEngineTest {
   @Test
   void shouldHaveChangedVersionTag() {
     Deployment deployment =
-        repositoryService()
-            .createDeployment()
-            .name("test")
-            .addClasspathResource("test.bpmn")
-            .deploy();
+      repositoryService()
+        .createDeployment()
+        .name("test")
+        .addClasspathResource("test.bpmn")
+        .deploy();
     assertThat(deployment).isNotNull();
 
     List<Resource> resourceEntities = repositoryService().getDeploymentResources(deployment.getId());

--- a/snippets/engine-plugin-deployer-version-tag/src/test/java/com/camunda/consulting/ProcessEngineTest.java
+++ b/snippets/engine-plugin-deployer-version-tag/src/test/java/com/camunda/consulting/ProcessEngineTest.java
@@ -1,0 +1,39 @@
+package com.camunda.consulting;
+
+import org.camunda.bpm.engine.RuntimeService;
+import org.camunda.bpm.engine.impl.persistence.entity.ResourceEntity;
+import org.camunda.bpm.engine.repository.Deployment;
+import org.camunda.bpm.engine.repository.Resource;
+import org.camunda.bpm.engine.test.junit5.ProcessEngineExtension;
+import org.camunda.bpm.model.bpmn.Bpmn;
+import org.camunda.bpm.model.bpmn.BpmnModelInstance;
+import org.camunda.bpm.model.bpmn.instance.Process;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.io.ByteArrayInputStream;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.camunda.bpm.engine.test.assertions.bpmn.BpmnAwareTests.*;
+
+@ExtendWith(ProcessEngineExtension.class)
+public class ProcessEngineTest {
+
+  @Test
+  void shouldHaveChangedVersionTag() {
+    Deployment deployment =
+        repositoryService()
+            .createDeployment()
+            .name("test")
+            .addClasspathResource("test.bpmn")
+            .deploy();
+    assertThat(deployment).isNotNull();
+
+    List<Resource> resourceEntities = repositoryService().getDeploymentResources(deployment.getId());
+    BpmnModelInstance modelInstance = Bpmn.readModelFromStream(new ByteArrayInputStream(resourceEntities.get(0).getBytes()));
+    modelInstance.getModelElementsByType(Process.class).forEach(process -> assertThat(process.getCamundaVersionTag()).isEqualTo("my-custom-tag"));
+  }
+
+}

--- a/snippets/engine-plugin-deployer-version-tag/src/test/resources/camunda.cfg.xml
+++ b/snippets/engine-plugin-deployer-version-tag/src/test/resources/camunda.cfg.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans   http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+	<bean id="processEngineConfiguration"
+		class="org.camunda.bpm.engine.impl.cfg.StandaloneInMemProcessEngineConfiguration">
+
+		<property name="jdbcUrl"
+			value="jdbc:h2:mem:process-engine-test;DB_CLOSE_DELAY=1000;DB_CLOSE_ON_EXIT=FALSE" />
+		<property name="jdbcDriver" value="org.h2.Driver" />
+		<property name="jdbcUsername" value="sa" />
+		<property name="jdbcPassword" value="sa" />
+
+		<!-- Database configurations -->
+		<property name="databaseSchemaUpdate" value="true" />
+
+		<!-- job executor configurations -->
+		<property name="jobExecutorActivate" value="false" />
+
+		<property name="history" value="full" />
+
+		<property name="defaultSerializationFormat"
+			value="application/json" />
+		<property name="processEnginePlugins">
+			<list>
+				<ref bean="registerDeploymentVersionTagChangePlugin" />
+			</list>
+		</property>
+		<property name="expressionManager">
+			<bean
+				class="org.camunda.bpm.engine.test.mock.MockExpressionManager" />
+		</property>
+	</bean>
+	<bean id="registerDeploymentVersionTagChangePlugin"
+		class="com.camunda.consulting.RegisterDeploymentVersionTagChangePlugin" />
+</beans>

--- a/snippets/engine-plugin-deployer-version-tag/src/test/resources/test.bpmn
+++ b/snippets/engine-plugin-deployer-version-tag/src/test/resources/test.bpmn
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_03prvk6" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.6.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.18.0">
+  <bpmn:process id="TestProcess" name="Test" isExecutable="true">
+    <bpmn:startEvent id="ProcessStartedStartEvent" name="Process started">
+      <bpmn:outgoing>Flow_0xt8rc5</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="ProcessEndedEndEvent" name="Process ended">
+      <bpmn:incoming>Flow_0xt8rc5</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0xt8rc5" sourceRef="ProcessStartedStartEvent" targetRef="ProcessEndedEndEvent" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="TestProcess">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="ProcessStartedStartEvent">
+        <dc:Bounds x="179" y="79" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="159" y="122" width="77" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1vkp013_di" bpmnElement="ProcessEndedEndEvent">
+        <dc:Bounds x="272" y="79" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="253" y="122" width="74" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0xt8rc5_di" bpmnElement="Flow_0xt8rc5">
+        <di:waypoint x="215" y="97" />
+        <di:waypoint x="272" y="97" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
Added Camunda 7 snippet with pre-init deployer plugin to add a custom version tag to each BPMN file.